### PR TITLE
[6.12] Track btrfs patches

### DIFF
--- a/fs/btrfs/Kconfig
+++ b/fs/btrfs/Kconfig
@@ -78,6 +78,15 @@ config BTRFS_ASSERT
 
 	  If unsure, say N.
 
+config BTRFS_EXPERIMENTAL
+	bool "Btrfs experimental features"
+	depends on BTRFS_FS
+	help
+	  Enable experimental features.  These features may not be stable enough
+	  for end users.  This is meant for btrfs developers only.
+
+	  If unsure, say N.
+
 config BTRFS_FS_REF_VERIFY
 	bool "Btrfs with the ref verify tool compiled in"
 	depends on BTRFS_FS

--- a/fs/btrfs/backref.c
+++ b/fs/btrfs/backref.c
@@ -1127,6 +1127,7 @@ static int add_inline_refs(struct btrfs_backref_walk_ctx *ctx,
 		if (ret)
 			return ret;
 		ptr += btrfs_extent_inline_ref_size(type);
+		cond_resched();
 	}
 
 	return 0;
@@ -1230,7 +1231,7 @@ static int add_keyed_refs(struct btrfs_backref_walk_ctx *ctx,
 		}
 		if (ret)
 			return ret;
-
+		cond_resched();
 	}
 
 	return ret;

--- a/fs/btrfs/bio.c
+++ b/fs/btrfs/bio.c
@@ -450,6 +450,14 @@ static void btrfs_submit_dev_bio(struct btrfs_device *dev, struct bio *bio)
 		(unsigned long)dev->bdev->bd_dev, btrfs_dev_name(dev),
 		dev->devid, bio->bi_iter.bi_size);
 
+	/*
+	 * Track reads if tracking is enabled; ignore I/O operations before
+	 * fully initialized.
+	 */
+	if (dev->fs_devices->fs_stats && bio_op(bio) == REQ_OP_READ && dev->fs_info)
+		percpu_counter_add(&dev->fs_info->stats_read_blocks,
+				   bio->bi_iter.bi_size >> dev->fs_info->sectorsize_bits);
+
 	if (bio->bi_opf & REQ_BTRFS_CGROUP_PUNT)
 		blkcg_punt_bio_submit(bio);
 	else

--- a/fs/btrfs/disk-io.c
+++ b/fs/btrfs/disk-io.c
@@ -3324,6 +3324,7 @@ int __cold open_ctree(struct super_block *sb, struct btrfs_fs_devices *fs_device
 	fs_info->sectors_per_page = (PAGE_SIZE >> fs_info->sectorsize_bits);
 	fs_info->csums_per_leaf = BTRFS_MAX_ITEM_SIZE(fs_info) / fs_info->csum_size;
 	fs_info->stripesize = stripesize;
+	fs_info->fs_devices->fs_info = fs_info;
 
 	/*
 	 * Handle the space caching options appropriately now that we have the

--- a/fs/btrfs/disk-io.c
+++ b/fs/btrfs/disk-io.c
@@ -1259,6 +1259,7 @@ void btrfs_free_fs_info(struct btrfs_fs_info *fs_info)
 {
 	struct percpu_counter *em_counter = &fs_info->evictable_extent_maps;
 
+	percpu_counter_destroy(&fs_info->stats_read_blocks);
 	percpu_counter_destroy(&fs_info->dirty_metadata_bytes);
 	percpu_counter_destroy(&fs_info->delalloc_bytes);
 	percpu_counter_destroy(&fs_info->ordered_bytes);
@@ -2855,6 +2856,10 @@ static int init_mount_fs_info(struct btrfs_fs_info *fs_info, struct super_block 
 	spin_lock_init(&fs_info->extent_map_shrinker_lock);
 
 	ret = percpu_counter_init(&fs_info->dirty_metadata_bytes, 0, GFP_KERNEL);
+	if (ret)
+		return ret;
+
+	ret = percpu_counter_init(&fs_info->stats_read_blocks, 0, GFP_KERNEL);
 	if (ret)
 		return ret;
 

--- a/fs/btrfs/fs.h
+++ b/fs/btrfs/fs.h
@@ -625,6 +625,9 @@ struct btrfs_fs_info {
 	struct kobject *qgroups_kobj;
 	struct kobject *discard_kobj;
 
+	/* Track the number of blocks (sectors) read by the filesystem. */
+	struct percpu_counter stats_read_blocks;
+
 	/* Used to keep from writing metadata until there is a nice batch */
 	struct percpu_counter dirty_metadata_bytes;
 	struct percpu_counter delalloc_bytes;

--- a/fs/btrfs/super.c
+++ b/fs/btrfs/super.c
@@ -2468,6 +2468,9 @@ static __cold void btrfs_interface_exit(void)
 static int __init btrfs_print_mod_info(void)
 {
 	static const char options[] = ""
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+			", experimental=on"
+#endif
 #ifdef CONFIG_BTRFS_DEBUG
 			", debug=on"
 #endif

--- a/fs/btrfs/super.c
+++ b/fs/btrfs/super.c
@@ -2549,6 +2549,11 @@ static const struct init_sequence mod_init_seq[] = {
 	}, {
 		.init_func = extent_map_init,
 		.exit_func = extent_map_exit,
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	}, {
+		.init_func = btrfs_read_policy_init,
+		.exit_func = NULL,
+#endif
 	}, {
 		.init_func = ordered_data_init,
 		.exit_func = ordered_data_exit,

--- a/fs/btrfs/super.c
+++ b/fs/btrfs/super.c
@@ -2491,7 +2491,17 @@ static int __init btrfs_print_mod_info(void)
 			", fsverity=no"
 #endif
 			;
+
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	if (btrfs_get_mod_read_policy() == NULL)
+		pr_info("Btrfs loaded%s\n", options);
+	else
+		pr_info("Btrfs loaded%s, read_policy=%s\n",
+			 options, btrfs_get_mod_read_policy());
+#else
 	pr_info("Btrfs loaded%s\n", options);
+#endif
+
 	return 0;
 }
 

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -1316,14 +1316,16 @@ static ssize_t btrfs_read_policy_show(struct kobject *kobj,
 	int i;
 
 	for (i = 0; i < BTRFS_NR_READ_POLICY; i++) {
-		if (policy == i)
-			ret += sysfs_emit_at(buf, ret, "%s[%s]",
-					 (ret == 0 ? "" : " "),
-					 btrfs_read_policy_name[i]);
-		else
-			ret += sysfs_emit_at(buf, ret, "%s%s",
-					 (ret == 0 ? "" : " "),
-					 btrfs_read_policy_name[i]);
+		if (ret != 0)
+			ret += sysfs_emit_at(buf, ret, " ");
+
+		if (i == policy)
+			ret += sysfs_emit_at(buf, ret, "[");
+
+		ret += sysfs_emit_at(buf, ret, "%s", btrfs_read_policy_name[i]);
+
+		if (i == policy)
+			ret += sysfs_emit_at(buf, ret, "]");
 	}
 
 	ret += sysfs_emit_at(buf, ret, "\n");

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -1980,7 +1980,61 @@ static ssize_t btrfs_devinfo_type_show(struct kobject *kobj,
 
 	return scnprintf(buf, PAGE_SIZE, "0x%08llx\n", device->type);
 }
-BTRFS_ATTR(devid, type, btrfs_devinfo_type_show);
+
+static ssize_t btrfs_devinfo_type_store(struct kobject *kobj,
+				 struct kobj_attribute *a,
+				 const char *buf, size_t len)
+{
+	struct btrfs_fs_info *fs_info;
+	struct btrfs_root *root;
+	struct btrfs_device *device;
+	int ret;
+	struct btrfs_trans_handle *trans;
+
+	u64 type, prev_type;
+
+	device = container_of(kobj, struct btrfs_device, devid_kobj);
+	fs_info = device->fs_info;
+	if (!fs_info)
+		return -EPERM;
+
+	root = fs_info->chunk_root;
+	if (sb_rdonly(fs_info->sb))
+		return -EROFS;
+
+	ret = kstrtou64(buf, 0, &type);
+	if (ret < 0)
+		return -EINVAL;
+
+	/* for now, allow to touch only the 'allocation hint' bits */
+	if (type & ~((1 << BTRFS_DEV_ALLOCATION_MASK_BIT_COUNT) - 1))
+		return -EINVAL;
+
+	trans = btrfs_start_transaction(root, 1);
+	if (IS_ERR(trans))
+		return PTR_ERR(trans);
+
+	prev_type = device->type;
+	device->type = type;
+
+	ret = btrfs_update_device(trans, device);
+
+	if (ret < 0) {
+		btrfs_abort_transaction(trans, ret);
+		btrfs_end_transaction(trans);
+		goto abort;
+	}
+
+	ret = btrfs_commit_transaction(trans);
+	if (ret < 0)
+		goto abort;
+
+	return len;
+abort:
+	device->type = prev_type;
+	return  ret;
+}
+BTRFS_ATTR_RW(devid, type, btrfs_devinfo_type_show, btrfs_devinfo_type_store);
 
 /*
  * Information about one device.

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -1307,6 +1307,18 @@ BTRFS_ATTR(, temp_fsid, btrfs_temp_fsid_show);
 
 static const char * const btrfs_read_policy_name[] = { "pid" };
 
+static int btrfs_read_policy_to_enum(const char *str)
+{
+	char param[32] = {'\0'};
+
+	if (!str || strlen(str) == 0)
+		return 0;
+
+	strncpy(param, str, sizeof(param) - 1);
+
+	return sysfs_match_string(btrfs_read_policy_name, param);
+}
+
 static ssize_t btrfs_read_policy_show(struct kobject *kobj,
 				      struct kobj_attribute *a, char *buf)
 {
@@ -1338,21 +1350,19 @@ static ssize_t btrfs_read_policy_store(struct kobject *kobj,
 				       const char *buf, size_t len)
 {
 	struct btrfs_fs_devices *fs_devices = to_fs_devs(kobj);
-	int i;
+	int index;
 
-	for (i = 0; i < BTRFS_NR_READ_POLICY; i++) {
-		if (sysfs_streq(buf, btrfs_read_policy_name[i])) {
-			if (i != READ_ONCE(fs_devices->read_policy)) {
-				WRITE_ONCE(fs_devices->read_policy, i);
-				btrfs_info(fs_devices->fs_info,
-					   "read policy set to '%s'",
-					   btrfs_read_policy_name[i]);
-			}
-			return len;
-		}
+	index = btrfs_read_policy_to_enum(buf);
+	if (index < 0)
+		return -EINVAL;
+
+	if (index != READ_ONCE(fs_devices->read_policy)) {
+		WRITE_ONCE(fs_devices->read_policy, index);
+		btrfs_info(fs_devices->fs_info, "read policy set to '%s'",
+			   btrfs_read_policy_name[index]);
 	}
 
-	return -EINVAL;
+	return len;
 }
 BTRFS_ATTR_RW(, read_policy, btrfs_read_policy_show, btrfs_read_policy_store);
 

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -1972,6 +1972,16 @@ static ssize_t btrfs_devinfo_error_stats_show(struct kobject *kobj,
 }
 BTRFS_ATTR(devid, error_stats, btrfs_devinfo_error_stats_show);
 
+static ssize_t btrfs_devinfo_type_show(struct kobject *kobj,
+					    struct kobj_attribute *a, char *buf)
+{
+	struct btrfs_device *device = container_of(kobj, struct btrfs_device,
+						   devid_kobj);
+
+	return scnprintf(buf, PAGE_SIZE, "0x%08llx\n", device->type);
+}
+BTRFS_ATTR(devid, type, btrfs_devinfo_type_show);
+
 /*
  * Information about one device.
  *
@@ -1985,6 +1995,7 @@ static struct attribute *devid_attrs[] = {
 	BTRFS_ATTR_PTR(devid, replace_target),
 	BTRFS_ATTR_PTR(devid, scrub_speed_max),
 	BTRFS_ATTR_PTR(devid, writeable),
+	BTRFS_ATTR_PTR(devid, type),
 	NULL
 };
 ATTRIBUTE_GROUPS(devid);

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -2192,7 +2192,9 @@ static ssize_t btrfs_devinfo_read_stats_show(struct kobject *kobj,
 	if (read_wait && read_ios && read_wait >= read_ios)
 		avg_wait = div_u64(read_wait, read_ios);
 
-	return scnprintf(buf, PAGE_SIZE, "ios %lu wait %llu avg %llu\n", read_ios, read_wait, avg_wait);
+	return scnprintf(buf, PAGE_SIZE, "ios %lu wait %llu avg %llu age %llu\n",
+	                 read_ios, read_wait, avg_wait,
+	                 (u64)atomic64_read(&device->last_io_age));
 }
 BTRFS_ATTR(devid, read_stats, btrfs_devinfo_read_stats_show);
 #endif

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -2202,10 +2202,11 @@ static ssize_t btrfs_devinfo_read_stats_show(struct kobject *kobj,
 	return scnprintf(buf, PAGE_SIZE,
 	                 "cumulative ios %lu wait %llu avg %llu "
 	                 "checkpoint ios %ld wait %lld avg %llu "
-	                 "age %lld count %llu\n",
+	                 "age %lld count %llu ignored %lld\n",
 	                 read_ios, read_wait, avg_wait,
 	                 delta_read_ios, delta_read_wait, delta_avg_wait,
-	                 atomic64_read(&device->last_io_age), atomic64_read(&device->checkpoints));
+	                 atomic64_read(&device->last_io_age), atomic64_read(&device->checkpoints),
+	                 atomic64_read(&device->stripe_ignored));
 }
 BTRFS_ATTR(devid, read_stats, btrfs_devinfo_read_stats_show);
 #endif

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -1305,7 +1305,12 @@ static ssize_t btrfs_temp_fsid_show(struct kobject *kobj,
 }
 BTRFS_ATTR(, temp_fsid, btrfs_temp_fsid_show);
 
-static const char * const btrfs_read_policy_name[] = { "pid" };
+static const char * const btrfs_read_policy_name[] = {
+	"pid",
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	"round-robin",
+#endif
+};
 
 static int btrfs_read_policy_to_enum(const char *str, s64 *value)
 {
@@ -1347,6 +1352,12 @@ static ssize_t btrfs_read_policy_show(struct kobject *kobj,
 
 		ret += sysfs_emit_at(buf, ret, "%s", btrfs_read_policy_name[i]);
 
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+		if (i == BTRFS_READ_POLICY_RR)
+			ret += sysfs_emit_at(buf, ret, ":%d",
+				 READ_ONCE(fs_devices->rr_min_contig_read));
+#endif
+
 		if (i == policy)
 			ret += sysfs_emit_at(buf, ret, "]");
 	}
@@ -1368,6 +1379,42 @@ static ssize_t btrfs_read_policy_store(struct kobject *kobj,
 	if (index < 0)
 		return -EINVAL;
 
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	/* If moving out of RR then disable fs_stats */
+	if (fs_devices->read_policy == BTRFS_READ_POLICY_RR &&
+	    index != BTRFS_READ_POLICY_RR)
+		fs_devices->fs_stats = false;
+
+	if (index == BTRFS_READ_POLICY_RR) {
+		if (value != -1) {
+			u32 sectorsize = fs_devices->fs_info->sectorsize;
+
+			if (!IS_ALIGNED(value, sectorsize)) {
+				u64 temp_value = round_up(value, sectorsize);
+
+				btrfs_warn(fs_devices->fs_info,
+"read_policy: min contiguous read %lld should be multiples of the sectorsize %u, rounded to %llu",
+					  value, sectorsize, temp_value);
+				value = temp_value;
+			}
+		} else {
+			value = BTRFS_DEFAULT_RR_MIN_CONTIG_READ;
+		}
+
+		if (index != READ_ONCE(fs_devices->read_policy) ||
+		    value != READ_ONCE(fs_devices->rr_min_contig_read)) {
+			WRITE_ONCE(fs_devices->read_policy, index);
+			WRITE_ONCE(fs_devices->rr_min_contig_read, value);
+
+			btrfs_info(fs_devices->fs_info, "read policy set to '%s:%lld'",
+				   btrfs_read_policy_name[index], value);
+		}
+
+		fs_devices->fs_stats = true;
+
+		return len;
+	}
+#endif
 	if (index != READ_ONCE(fs_devices->read_policy)) {
 		WRITE_ONCE(fs_devices->read_policy, index);
 		btrfs_info(fs_devices->fs_info, "read policy set to '%s'",

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -1314,6 +1314,7 @@ static const char * const btrfs_read_policy_name[] = {
 	"round-robin",
 	"latency",
 	"latency-rr",
+	"queue",
 	"devid",
 #endif
 };
@@ -1329,7 +1330,7 @@ char *btrfs_get_mod_read_policy(void)
 /* Set perm 0, disable sys/module/btrfs/parameter/read_policy interface */
 module_param(read_policy, charp, 0);
 MODULE_PARM_DESC(read_policy,
-"Global read policy; pid (default), round-robin[:min_contig_read], latency, latency-rr[:min_contig_read], devid[:devid]");
+"Global read policy; pid (default), round-robin[:min_contig_read], latency, latency-rr[:min_contig_read], queue, devid[:devid]");
 #endif
 
 int btrfs_read_policy_to_enum(const char *str, s64 *value)

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -2192,9 +2192,9 @@ static ssize_t btrfs_devinfo_read_stats_show(struct kobject *kobj,
 	if (read_wait && read_ios && read_wait >= read_ios)
 		avg_wait = div_u64(read_wait, read_ios);
 
-	return scnprintf(buf, PAGE_SIZE, "ios %lu wait %llu avg %llu age %llu\n",
+	return scnprintf(buf, PAGE_SIZE, "ios %lu wait %llu avg %llu age %lld\n",
 	                 read_ios, read_wait, avg_wait,
-	                 (u64)atomic64_read(&device->last_io_age));
+	                 atomic64_read(&device->last_io_age));
 }
 BTRFS_ATTR(devid, read_stats, btrfs_devinfo_read_stats_show);
 #endif

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -1309,6 +1309,7 @@ static const char * const btrfs_read_policy_name[] = {
 	"pid",
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	"round-robin",
+	"devid",
 #endif
 };
 
@@ -1356,8 +1357,11 @@ static ssize_t btrfs_read_policy_show(struct kobject *kobj,
 		if (i == BTRFS_READ_POLICY_RR)
 			ret += sysfs_emit_at(buf, ret, ":%d",
 				 READ_ONCE(fs_devices->rr_min_contig_read));
-#endif
 
+		if (i == BTRFS_READ_POLICY_DEVID)
+			ret += sysfs_emit_at(buf, ret, ":%llu",
+					     READ_ONCE(fs_devices->read_devid));
+#endif
 		if (i == policy)
 			ret += sysfs_emit_at(buf, ret, "]");
 	}
@@ -1411,6 +1415,33 @@ static ssize_t btrfs_read_policy_store(struct kobject *kobj,
 		}
 
 		fs_devices->fs_stats = true;
+
+		return len;
+	}
+
+	if (index == BTRFS_READ_POLICY_DEVID) {
+
+		if (value != -1) {
+			BTRFS_DEV_LOOKUP_ARGS(args);
+
+			/* Validate input devid */
+			args.devid = value;
+			if (btrfs_find_device(fs_devices, &args) == NULL)
+				return -EINVAL;
+		} else {
+			/* Set default devid to the devid of the latest device */
+			value = fs_devices->latest_dev->devid;
+		}
+
+		if (index != READ_ONCE(fs_devices->read_policy) ||
+		    (value != READ_ONCE(fs_devices->read_devid))) {
+			WRITE_ONCE(fs_devices->read_policy, index);
+			WRITE_ONCE(fs_devices->read_devid, value);
+
+			btrfs_info(fs_devices->fs_info, "read policy set to '%s:%llu'",
+				   btrfs_read_policy_name[index], value);
+
+		}
 
 		return len;
 	}

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -1310,6 +1310,7 @@ static const char * const btrfs_read_policy_name[] = {
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	"round-robin",
 	"latency",
+	"latency-rr",
 	"devid",
 #endif
 };
@@ -1325,7 +1326,7 @@ char *btrfs_get_mod_read_policy(void)
 /* Set perm 0, disable sys/module/btrfs/parameter/read_policy interface */
 module_param(read_policy, charp, 0);
 MODULE_PARM_DESC(read_policy,
-"Global read policy; pid (default), round-robin[:min_contig_read], latency, devid[:devid]");
+"Global read policy; pid (default), round-robin[:min_contig_read], latency, latency-rr[:min_contig_read], devid[:devid]");
 #endif
 
 int btrfs_read_policy_to_enum(const char *str, s64 *value)
@@ -1383,6 +1384,10 @@ static ssize_t btrfs_read_policy_show(struct kobject *kobj,
 		ret += sysfs_emit_at(buf, ret, "%s", btrfs_read_policy_name[i]);
 
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
+		if (i == BTRFS_READ_POLICY_LATENCY_RR)
+			ret += sysfs_emit_at(buf, ret, ":%d",
+				 READ_ONCE(fs_devices->rr_min_contig_read));
+
 		if (i == BTRFS_READ_POLICY_RR)
 			ret += sysfs_emit_at(buf, ret, ":%d",
 				 READ_ONCE(fs_devices->rr_min_contig_read));
@@ -1418,7 +1423,11 @@ static ssize_t btrfs_read_policy_store(struct kobject *kobj,
 	    index != BTRFS_READ_POLICY_RR)
 		fs_devices->fs_stats = false;
 
-	if (index == BTRFS_READ_POLICY_RR) {
+	if (fs_devices->read_policy == BTRFS_READ_POLICY_LATENCY_RR &&
+	    index != BTRFS_READ_POLICY_LATENCY_RR)
+		fs_devices->fs_stats = false;
+
+	if ((index == BTRFS_READ_POLICY_RR) || (index == BTRFS_READ_POLICY_LATENCY_RR)) {
 		if (value != -1) {
 			u32 sectorsize = fs_devices->fs_info->sectorsize;
 

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -10,6 +10,9 @@
 #include <linux/completion.h>
 #include <linux/bug.h>
 #include <linux/list.h>
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+#include <linux/part_stat.h>
+#endif
 #include <crypto/hash.h>
 #include "messages.h"
 #include "ctree.h"
@@ -2176,12 +2179,33 @@ abort:
 }
 BTRFS_ATTR_RW(devid, type, btrfs_devinfo_type_show, btrfs_devinfo_type_store);
 
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+static ssize_t btrfs_devinfo_read_stats_show(struct kobject *kobj,
+                                                       struct kobj_attribute *a, char *buf)
+{
+	struct btrfs_device *device = container_of(kobj, struct btrfs_device,
+						   devid_kobj);
+	u64 read_wait = part_stat_read(device->bdev, nsecs[READ]);
+	unsigned long read_ios = part_stat_read(device->bdev, ios[READ]);
+
+	u64 avg_wait = 0;
+	if (read_wait && read_ios && read_wait >= read_ios)
+		avg_wait = div_u64(read_wait, read_ios);
+
+	return scnprintf(buf, PAGE_SIZE, "ios %lu wait %llu avg %llu\n", read_ios, read_wait, avg_wait);
+}
+BTRFS_ATTR(devid, read_stats, btrfs_devinfo_read_stats_show);
+#endif
+
 /*
  * Information about one device.
  *
  * Path: /sys/fs/btrfs/<uuid>/devinfo/<devid>/
  */
 static struct attribute *devid_attrs[] = {
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	BTRFS_ATTR_PTR(devid, read_stats),
+#endif
 	BTRFS_ATTR_PTR(devid, error_stats),
 	BTRFS_ATTR_PTR(devid, fsid),
 	BTRFS_ATTR_PTR(devid, in_fs_metadata),

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -1313,7 +1313,21 @@ static const char * const btrfs_read_policy_name[] = {
 #endif
 };
 
-static int btrfs_read_policy_to_enum(const char *str, s64 *value)
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+/* Global module configuration parameters */
+static char *read_policy;
+char *btrfs_get_mod_read_policy(void)
+{
+	return read_policy;
+}
+
+/* Set perm 0, disable sys/module/btrfs/parameter/read_policy interface */
+module_param(read_policy, charp, 0);
+MODULE_PARM_DESC(read_policy,
+"Global read policy; pid (default), round-robin[:min_contig_read], devid[:devid]");
+#endif
+
+int btrfs_read_policy_to_enum(const char *str, s64 *value)
 {
 	char param[32] = {'\0'};
 	char *__maybe_unused value_str;
@@ -1335,6 +1349,20 @@ static int btrfs_read_policy_to_enum(const char *str, s64 *value)
 
 	return sysfs_match_string(btrfs_read_policy_name, param);
 }
+
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+int __init btrfs_read_policy_init(void)
+{
+	s64 value;
+
+	if (btrfs_read_policy_to_enum(read_policy, &value) == -EINVAL) {
+		btrfs_err(NULL, "invalid read policy or value %s", read_policy);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+#endif
 
 static ssize_t btrfs_read_policy_show(struct kobject *kobj,
 				      struct kobj_attribute *a, char *buf)

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -2186,15 +2186,26 @@ static ssize_t btrfs_devinfo_read_stats_show(struct kobject *kobj,
 	struct btrfs_device *device = container_of(kobj, struct btrfs_device,
 						   devid_kobj);
 	u64 read_wait = part_stat_read(device->bdev, nsecs[READ]);
+	u64 last_nsecs_read = (u64)atomic64_read(&device->last_nsecs_read);
 	unsigned long read_ios = part_stat_read(device->bdev, ios[READ]);
+	unsigned long last_ios_read = (unsigned long)atomic64_read(&device->last_ios_read);
+	s64 delta_read_wait = read_wait - last_nsecs_read;
+	long delta_read_ios = read_ios - last_ios_read;
+	u64 avg_wait = 0, delta_avg_wait = 0;
 
-	u64 avg_wait = 0;
 	if (read_wait && read_ios && read_wait >= read_ios)
 		avg_wait = div_u64(read_wait, read_ios);
 
-	return scnprintf(buf, PAGE_SIZE, "ios %lu wait %llu avg %llu age %lld\n",
+	if (delta_read_wait > 0 && delta_read_ios > 0 && delta_read_wait >= delta_read_ios)
+		delta_avg_wait = div_u64(delta_read_wait, delta_read_ios);
+
+	return scnprintf(buf, PAGE_SIZE,
+	                 "cumulative ios %lu wait %llu avg %llu "
+	                 "checkpoint ios %ld wait %lld avg %llu "
+	                 "age %lld count %llu\n",
 	                 read_ios, read_wait, avg_wait,
-	                 atomic64_read(&device->last_io_age));
+	                 delta_read_ios, delta_read_wait, delta_avg_wait,
+	                 atomic64_read(&device->last_io_age), atomic64_read(&device->checkpoints));
 }
 BTRFS_ATTR(devid, read_stats, btrfs_devinfo_read_stats_show);
 #endif

--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -1309,6 +1309,7 @@ static const char * const btrfs_read_policy_name[] = {
 	"pid",
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	"round-robin",
+	"latency",
 	"devid",
 #endif
 };
@@ -1324,7 +1325,7 @@ char *btrfs_get_mod_read_policy(void)
 /* Set perm 0, disable sys/module/btrfs/parameter/read_policy interface */
 module_param(read_policy, charp, 0);
 MODULE_PARM_DESC(read_policy,
-"Global read policy; pid (default), round-robin[:min_contig_read], devid[:devid]");
+"Global read policy; pid (default), round-robin[:min_contig_read], latency, devid[:devid]");
 #endif
 
 int btrfs_read_policy_to_enum(const char *str, s64 *value)

--- a/fs/btrfs/sysfs.h
+++ b/fs/btrfs/sysfs.h
@@ -47,5 +47,10 @@ void btrfs_sysfs_del_qgroups(struct btrfs_fs_info *fs_info);
 int btrfs_sysfs_add_qgroups(struct btrfs_fs_info *fs_info);
 void btrfs_sysfs_del_one_qgroup(struct btrfs_fs_info *fs_info,
 				struct btrfs_qgroup *qgroup);
+int btrfs_read_policy_to_enum(const char *str, s64 *value);
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+int __init btrfs_read_policy_init(void);
+char *btrfs_get_mod_read_policy(void);
+#endif
 
 #endif

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -2882,7 +2882,7 @@ error:
 	return ret;
 }
 
-static noinline int btrfs_update_device(struct btrfs_trans_handle *trans,
+noinline int btrfs_update_device(struct btrfs_trans_handle *trans,
 					struct btrfs_device *device)
 {
 	int ret;

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -184,6 +184,19 @@ enum btrfs_raid_types __attribute_const__ btrfs_bg_flags_to_raid_index(u64 flags
 	return BTRFS_BG_FLAG_TO_INDEX(profile);
 }
 
+#define BTRFS_DEV_ALLOCATION_MASK ((1ULL << \
+		BTRFS_DEV_ALLOCATION_MASK_BIT_COUNT) - 1)
+#define BTRFS_DEV_ALLOCATION_MASK_COUNT (1ULL << \
+		BTRFS_DEV_ALLOCATION_MASK_BIT_COUNT)
+
+static const char alloc_hint_map[BTRFS_DEV_ALLOCATION_MASK_COUNT] = {
+	[BTRFS_DEV_ALLOCATION_DATA_ONLY] = -1,
+	[BTRFS_DEV_ALLOCATION_PREFERRED_DATA] = 0,
+	[BTRFS_DEV_ALLOCATION_PREFERRED_METADATA] = 1,
+	[BTRFS_DEV_ALLOCATION_METADATA_ONLY] = 2,
+	/* the other values are set to 0 */
+};
+
 const char *btrfs_bg_type_to_raid_name(u64 flags)
 {
 	const int index = btrfs_bg_flags_to_raid_index(flags);
@@ -5022,13 +5035,18 @@ static int btrfs_add_system_chunk(struct btrfs_fs_info *fs_info,
 }
 
 /*
- * sort the devices in descending order by max_avail, total_avail
+ * sort the devices in descending order by alloc_hint,
+ * max_avail, total_avail
  */
 static int btrfs_cmp_device_info(const void *a, const void *b)
 {
 	const struct btrfs_device_info *di_a = a;
 	const struct btrfs_device_info *di_b = b;
 
+	if (di_a->alloc_hint > di_b->alloc_hint)
+		return -1;
+	if (di_a->alloc_hint < di_b->alloc_hint)
+		return 1;
 	if (di_a->max_avail > di_b->max_avail)
 		return -1;
 	if (di_a->max_avail < di_b->max_avail)
@@ -5181,6 +5199,8 @@ static int gather_device_info(struct btrfs_fs_devices *fs_devices,
 	int ndevs = 0;
 	u64 max_avail;
 	u64 dev_offset;
+	int hint;
+	int i;
 
 	/*
 	 * in the first pass through the devices list, we gather information
@@ -5233,13 +5253,88 @@ static int gather_device_info(struct btrfs_fs_devices *fs_devices,
 		devices_info[ndevs].max_avail = max_avail;
 		devices_info[ndevs].total_avail = total_avail;
 		devices_info[ndevs].dev = device;
+
+		if ((ctl->type & BTRFS_BLOCK_GROUP_DATA) &&
+		     (ctl->type & BTRFS_BLOCK_GROUP_METADATA)) {
+			/*
+			 * if mixed bg set all the alloc_hint
+			 * fields to the same value, so the sorting
+			 * is not affected
+			 */
+			devices_info[ndevs].alloc_hint = 0;
+		} else if (ctl->type & BTRFS_BLOCK_GROUP_DATA) {
+			hint = device->type & BTRFS_DEV_ALLOCATION_MASK;
+
+			/*
+			 * skip BTRFS_DEV_METADATA_ONLY disks
+			 */
+			if (hint == BTRFS_DEV_ALLOCATION_METADATA_ONLY)
+				continue;
+			/*
+			 * if a data chunk must be allocated,
+			 * sort also by hint (data disk
+			 * higher priority)
+			 */
+			devices_info[ndevs].alloc_hint = -alloc_hint_map[hint];
+		} else { /* BTRFS_BLOCK_GROUP_METADATA */
+			hint = device->type & BTRFS_DEV_ALLOCATION_MASK;
+
+			/*
+			 * skip BTRFS_DEV_DATA_ONLY disks
+			 */
+			if (hint == BTRFS_DEV_ALLOCATION_DATA_ONLY)
+				continue;
+			/*
+			 * if a data chunk must be allocated,
+			 * sort also by hint (metadata hint
+			 * higher priority)
+			 */
+			devices_info[ndevs].alloc_hint = alloc_hint_map[hint];
+		}
+
 		++ndevs;
 	}
 	ctl->ndevs = ndevs;
 
 	/*
+	 * no devices available
+	 */
+	if (!ndevs)
+		return 0;
+
+	/*
 	 * now sort the devices by hole size / available space
 	 */
+	sort(devices_info, ndevs, sizeof(struct btrfs_device_info),
+	     btrfs_cmp_device_info, NULL);
+
+	/*
+	 * select the minimum set of disks grouped by hint that
+	 * can host the chunk
+	 */
+	ndevs = 0;
+	while (ndevs < ctl->ndevs) {
+		hint = devices_info[ndevs++].alloc_hint;
+		while (ndevs < ctl->ndevs &&
+		       devices_info[ndevs].alloc_hint == hint)
+				ndevs++;
+		if (ndevs >= ctl->devs_min)
+			break;
+	}
+
+	BUG_ON(ndevs > ctl->ndevs);
+	ctl->ndevs = ndevs;
+
+	/*
+	 * the next layers require the devices_info ordered by
+	 * max_avail. If we are returing two (or more) different
+	 * group of alloc_hint, this is not always true. So sort
+	 * these gain.
+	 */
+
+	for (i = 0 ; i < ndevs ; i++)
+		devices_info[i].alloc_hint = 0;
+
 	sort(devices_info, ndevs, sizeof(struct btrfs_device_info),
 	     btrfs_cmp_device_info, NULL);
 

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -190,6 +190,7 @@ enum btrfs_raid_types __attribute_const__ btrfs_bg_flags_to_raid_index(u64 flags
 		BTRFS_DEV_ALLOCATION_MASK_BIT_COUNT)
 
 static const char alloc_hint_map[BTRFS_DEV_ALLOCATION_MASK_COUNT] = {
+	[BTRFS_DEV_ALLOCATION_NONE_ONLY] = -99,
 	[BTRFS_DEV_ALLOCATION_DATA_ONLY] = -1,
 	[BTRFS_DEV_ALLOCATION_PREFERRED_DATA] = 0,
 	[BTRFS_DEV_ALLOCATION_PREFERRED_METADATA] = 1,
@@ -5272,6 +5273,11 @@ static int gather_device_info(struct btrfs_fs_devices *fs_devices,
 			if (hint == BTRFS_DEV_ALLOCATION_METADATA_ONLY)
 				continue;
 			/*
+			 * skip BTRFS_DEV_NONE_ONLY disks
+			 */
+			if (hint == BTRFS_DEV_ALLOCATION_NONE_ONLY)
+				continue;
+			/*
 			 * if a data chunk must be allocated,
 			 * sort also by hint (data disk
 			 * higher priority)
@@ -5284,6 +5290,11 @@ static int gather_device_info(struct btrfs_fs_devices *fs_devices,
 			 * skip BTRFS_DEV_DATA_ONLY disks
 			 */
 			if (hint == BTRFS_DEV_ALLOCATION_DATA_ONLY)
+				continue;
+			/*
+			 * skip BTRFS_DEV_NONE_ONLY disks
+			 */
+			if (hint == BTRFS_DEV_ALLOCATION_NONE_ONLY)
 				continue;
 			/*
 			 * if a data chunk must be allocated,

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -194,6 +194,7 @@ static const char alloc_hint_map[BTRFS_DEV_ALLOCATION_MASK_COUNT] = {
 	[BTRFS_DEV_ALLOCATION_PREFERRED_DATA] = 0,
 	[BTRFS_DEV_ALLOCATION_PREFERRED_METADATA] = 1,
 	[BTRFS_DEV_ALLOCATION_METADATA_ONLY] = 2,
+	[BTRFS_DEV_ALLOCATION_PREFERRED_NONE] = 99,
 	/* the other values are set to 0 */
 };
 
@@ -5289,7 +5290,10 @@ static int gather_device_info(struct btrfs_fs_devices *fs_devices,
 			 * sort also by hint (metadata hint
 			 * higher priority)
 			 */
-			devices_info[ndevs].alloc_hint = alloc_hint_map[hint];
+			if (hint == BTRFS_DEV_ALLOCATION_PREFERRED_NONE)
+				devices_info[ndevs].alloc_hint = -alloc_hint_map[hint];
+			else
+				devices_info[ndevs].alloc_hint = alloc_hint_map[hint];
 		}
 
 		++ndevs;

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6008,13 +6008,28 @@ static int btrfs_read_preferred(struct btrfs_chunk_map *map, int first,
 }
 
 /*
+ * btrfs_device_read_latency
+ *
+ * Compute the average latency of the device by dividing total latency by
+ * number of IOs.
+ */
+static u64 btrfs_device_read_latency(struct btrfs_device *device)
+{
+	u64 read_wait = part_stat_read(device->bdev, nsecs[READ]);
+	unsigned long read_ios = part_stat_read(device->bdev, ios[READ]);
+	u64 avg_wait = 0;
+
+	if (read_wait && read_ios && read_wait >= read_ios)
+		avg_wait = div_u64(read_wait, read_ios);
+
+	return avg_wait;
+}
+
+/*
  * btrfs_best_stripe
  *
  * Select a stripe for reading using the average latency:
- *
- * 1. Compute the average latency of the device by dividing total latency
- *    by number of IOs.
- * 2. Store minimum latency and selected stripe in best_wait / best_stripe.
+ * Store minimum latency and selected stripe in best_wait / best_stripe.
  *
  * Will always find at least one stripe.
  */
@@ -6022,22 +6037,11 @@ static void btrfs_best_stripe(struct btrfs_fs_info *fs_info,
                               struct btrfs_chunk_map *map, int first,
                               int num_stripes, u64 *best_wait, int *best_stripe)
 {
-	int index;
 	*best_wait = U64_MAX;
 	*best_stripe = 0;
 
-	for (index = first; index < first + num_stripes; index++) {
-		u64 read_wait;
-		u64 avg_wait = 0;
-		unsigned long read_ios;
-		struct btrfs_device *device = map->stripes[index].dev;
-
-		read_wait = part_stat_read(device->bdev, nsecs[READ]);
-		read_ios = part_stat_read(device->bdev, ios[READ]);
-
-		if (read_wait && read_ios && read_wait >= read_ios)
-			avg_wait = div_u64(read_wait, read_ios);
-
+	for (int index = first; index < first + num_stripes; index++) {
+		u64 avg_wait = btrfs_device_read_latency(map->stripes[index].dev);
 		if (*best_wait > avg_wait) {
 			*best_wait = avg_wait;
 			*best_stripe = index;

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6202,6 +6202,7 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 	/* age each possible stripe by 1 IO */
 	for (int i = first; i < first + num_stripes; i++) {
 		atomic64_inc(&map->stripes[i].dev->last_io_age);
+		atomic64_inc(&map->stripes[i].dev->stripe_ignored);
 	}
 #endif
 
@@ -6273,9 +6274,10 @@ out:
 			atomic64_set(&pref_dev->last_io_age, -BTRFS_DEVICE_LATENCY_CHECKPOINT_BURST_IO);
 			atomic64_set(&pref_dev->last_nsecs_read, part_stat_read(pref_dev->bdev, nsecs[READ]));
 			atomic64_set(&pref_dev->last_ios_read, part_stat_read(pref_dev->bdev, ios[READ]));
-		} else if (current_age >= 0) {
+		} else if (current_age > 0) {
 			atomic64_set(&pref_dev->last_io_age, 0);
 		}
+		atomic64_dec(&pref_dev->stripe_ignored);
 
 		spin_unlock(&pref_dev->latency_lock);
 	} while (0);

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -7678,7 +7678,7 @@ int btrfs_init_dev_stats(struct btrfs_fs_info *fs_info)
 	list_for_each_entry(device, &fs_devices->devices, dev_list) {
 		ret = btrfs_device_init_dev_stats(device, path);
 		if (ret)
-			goto out;
+			return ret;
 	}
 	list_for_each_entry(seed_devs, &fs_devices->seed_list, seed_list) {
 		list_for_each_entry(device, &seed_devs->devices, dev_list) {

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6021,7 +6021,7 @@ static u64 btrfs_device_read_latency(struct btrfs_device *device)
 	u64 last_io_age = (u64)atomic64_read(&device->last_io_age);
 	u64 avg_wait = 0;
 
-	if (last_io_age < BTRFS_MAX_AGE_FOR_VALID_LATENCY
+	if (last_io_age >= 0 && last_io_age < BTRFS_MAX_AGE_FOR_VALID_LATENCY
 	    && read_wait && read_ios && read_wait >= read_ios)
 		avg_wait = div_u64(read_wait, read_ios);
 
@@ -6174,6 +6174,7 @@ static int btrfs_read_fastest_rr(struct btrfs_fs_info *fs_info,
 }
 #endif
 
+#define BTRFS_OLD_AGE_IO_BURST 20
 static int find_live_mirror(struct btrfs_fs_info *fs_info,
 			    struct btrfs_chunk_map *map, int first,
 			    int dev_replace_is_ongoing)
@@ -6256,7 +6257,18 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 out:
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	/* reset age of selected stripe */
-	atomic64_set(&map->stripes[preferred_mirror].dev->last_io_age, 0);
+	s64 current_age, new_age;
+	do {
+		current_age = atomic64_read(&map->stripes[preferred_mirror].dev->last_io_age);
+
+		if (current_age >= BTRFS_MAX_AGE_FOR_VALID_LATENCY) {
+			new_age = -BTRFS_OLD_AGE_IO_BURST;
+		} else if (current_age >= 0) {
+			new_age = 0;
+		} else {
+			return preferred_mirror;
+		}
+	} while (unlikely(atomic64_cmpxchg(&map->stripes[preferred_mirror].dev->last_io_age, current_age, new_age) != current_age));
 #endif
 
 	/* we couldn't find one that doesn't fail.  Just return something

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6098,21 +6098,22 @@ static int btrfs_read_rr(struct btrfs_chunk_map *map, int first, int num_stripe)
 	unsigned int read_cycle;
 	unsigned int total_reads;
 	unsigned int min_reads_per_dev;
+	int count_stripes = 0;
 
 	total_reads = percpu_counter_sum(&fs_info->stats_read_blocks);
 	min_reads_per_dev = READ_ONCE(fs_info->fs_devices->rr_min_contig_read) >>
 						       fs_info->sectorsize_bits;
 
-	for (int index = 0, i = first; i < first + num_stripe; i++) {
-		stripes[index].devid = map->stripes[i].dev->devid;
-		stripes[index].num = i;
-		index++;
+	for (int i = first; i < first + num_stripe; i++) {
+		stripes[count_stripes].devid = map->stripes[i].dev->devid;
+		stripes[count_stripes].num = i;
+		count_stripes++;
 	}
-	sort(stripes, num_stripe, sizeof(struct stripe_mirror),
+	sort(stripes, count_stripes, sizeof(struct stripe_mirror),
 	     btrfs_cmp_devid, NULL);
 
 	read_cycle = total_reads / min_reads_per_dev;
-	return stripes[read_cycle % num_stripe].num;
+	return stripes[read_cycle % count_stripes].num;
 }
 #endif
 

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6016,18 +6016,22 @@ static int btrfs_read_preferred(struct btrfs_chunk_map *map, int first,
 #define BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE 30000
 static u64 btrfs_device_read_latency(struct btrfs_device *device)
 {
-	u64 read_wait = part_stat_read(device->bdev, nsecs[READ]);
-	u64 last_nsecs_read = (u64)atomic64_read(&device->last_nsecs_read);
-	unsigned long read_ios = part_stat_read(device->bdev, ios[READ]);
-	unsigned long last_ios_read = (unsigned long)atomic64_read(&device->last_ios_read);
-	u64 last_io_age = (u64)atomic64_read(&device->last_io_age);
 	u64 avg_wait = 0;
-	s64 delta_read_wait = read_wait - last_nsecs_read;
-	s64 delta_read_ios = read_ios - last_ios_read;
 
-	if (last_io_age >= 0 && last_io_age < BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE
-	    && delta_read_wait > 0 && delta_read_ios > 0 && delta_read_wait >= delta_read_ios)
-		avg_wait = div_u64(delta_read_wait, delta_read_ios);
+	if (likely(device->bdev)) {
+		u64 read_wait = part_stat_read(device->bdev, nsecs[READ]);
+		u64 last_nsecs_read = (u64)atomic64_read(&device->last_nsecs_read);
+		unsigned long read_ios = part_stat_read(device->bdev, ios[READ]);
+		unsigned long last_ios_read = (unsigned long)atomic64_read(&device->last_ios_read);
+		u64 last_io_age = (u64)atomic64_read(&device->last_io_age);
+
+		s64 delta_read_wait = read_wait - last_nsecs_read;
+		s64 delta_read_ios = read_ios - last_ios_read;
+
+		if (last_io_age >= 0 && last_io_age < BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE
+		    && delta_read_wait > 0 && delta_read_ios > 0 && delta_read_wait >= delta_read_ios)
+			avg_wait = div_u64(delta_read_wait, delta_read_ios);
+	}
 
 	return avg_wait;
 }
@@ -6084,7 +6088,8 @@ static int btrfs_read_earliest(struct btrfs_fs_info *fs_info,
 	int best_stripe = 0;
 
 	for (int index = first; index < first + num_stripes; index++) {
-		u64 in_flight = part_in_flight(map->stripes[index].dev->bdev);
+		struct block_device *part = map->stripes[index].dev->bdev;
+		u64 in_flight = part ? part_in_flight(part) : 0;
 		if (best_in_flight > in_flight) {
 			best_in_flight = in_flight;
 			best_stripe = index;
@@ -6311,7 +6316,7 @@ out:
 		spin_lock(&pref_dev->latency_lock);
 
 		current_age = atomic64_read(&pref_dev->last_io_age);
-		if (current_age >= BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE) {
+		if (current_age >= BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE && pref_dev->bdev) {
 			atomic64_inc(&pref_dev->checkpoints);
 			atomic64_set(&pref_dev->last_io_age, -BTRFS_DEVICE_LATENCY_CHECKPOINT_BURST_IO);
 			atomic64_set(&pref_dev->last_nsecs_read, part_stat_read(pref_dev->bdev, nsecs[READ]));

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -1235,6 +1235,9 @@ static int open_fs_devices(struct btrfs_fs_devices *fs_devices,
 	fs_devices->total_rw_bytes = 0;
 	fs_devices->chunk_alloc_policy = BTRFS_CHUNK_ALLOC_REGULAR;
 	fs_devices->read_policy = BTRFS_READ_POLICY_PID;
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	fs_devices->rr_min_contig_read = BTRFS_DEFAULT_RR_MIN_CONTIG_READ;
+#endif
 
 	return 0;
 }
@@ -5970,6 +5973,65 @@ int btrfs_is_parity_mirror(struct btrfs_fs_info *fs_info, u64 logical, u64 len)
 	return ret;
 }
 
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+struct stripe_mirror {
+	u64 devid;
+	int num;
+};
+
+static int btrfs_cmp_devid(const void *a, const void *b)
+{
+	const struct stripe_mirror *s1 = (struct stripe_mirror *)a;
+	const struct stripe_mirror *s2 = (struct stripe_mirror *)b;
+
+	if (s1->devid < s2->devid)
+		return -1;
+	if (s1->devid > s2->devid)
+		return 1;
+	return 0;
+}
+
+/*
+ * btrfs_read_rr.
+ *
+ * Select a stripe for reading using a round-robin algorithm:
+ *
+ *  1. Compute the read cycle as the total sectors read divided by the minimum
+ *  sectors per device.
+ *  2. Determine the stripe number for the current read by taking the modulus
+ *  of the read cycle with the total number of stripes:
+ *
+ *      stripe index = (total sectors / min sectors per dev) % num stripes
+ *
+ * The calculated stripe index is then used to select the corresponding device
+ * from the list of devices, which is ordered by devid.
+ */
+static int btrfs_read_rr(struct btrfs_chunk_map *map, int first, int num_stripe)
+{
+	struct stripe_mirror stripes[BTRFS_RAID1_MAX_MIRRORS] = { 0 };
+	struct btrfs_device *device  = map->stripes[first].dev;
+	struct btrfs_fs_info *fs_info = device->fs_devices->fs_info;
+	unsigned int read_cycle;
+	unsigned int total_reads;
+	unsigned int min_reads_per_dev;
+
+	total_reads = percpu_counter_sum(&fs_info->stats_read_blocks);
+	min_reads_per_dev = READ_ONCE(fs_info->fs_devices->rr_min_contig_read) >>
+						       fs_info->sectorsize_bits;
+
+	for (int index = 0, i = first; i < first + num_stripe; i++) {
+		stripes[index].devid = map->stripes[i].dev->devid;
+		stripes[index].num = i;
+		index++;
+	}
+	sort(stripes, num_stripe, sizeof(struct stripe_mirror),
+	     btrfs_cmp_devid, NULL);
+
+	read_cycle = total_reads / min_reads_per_dev;
+	return stripes[read_cycle % num_stripe].num;
+}
+#endif
+
 static int find_live_mirror(struct btrfs_fs_info *fs_info,
 			    struct btrfs_chunk_map *map, int first,
 			    int dev_replace_is_ongoing)
@@ -5999,6 +6061,11 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 	case BTRFS_READ_POLICY_PID:
 		preferred_mirror = first + (current->pid % num_stripes);
 		break;
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	case BTRFS_READ_POLICY_RR:
+		preferred_mirror = btrfs_read_rr(map, first, num_stripes);
+		break;
+#endif
 	}
 
 	if (dev_replace_is_ongoing &&

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6007,15 +6007,26 @@ static int btrfs_read_preferred(struct btrfs_chunk_map *map, int first,
 	return first;
 }
 
-static int btrfs_best_stripe(struct btrfs_fs_info *fs_info,
-			     struct btrfs_chunk_map *map, int first,
-			     int num_stripe)
+/*
+ * btrfs_best_stripe
+ *
+ * Select a stripe for reading using the average latency:
+ *
+ * 1. Compute the average latency of the device by dividing total latency
+ *    by number of IOs.
+ * 2. Store minimum latency and selected stripe in best_wait / best_stripe.
+ *
+ * Will always find at least one stripe.
+ */
+static void btrfs_best_stripe(struct btrfs_fs_info *fs_info,
+                              struct btrfs_chunk_map *map, int first,
+                              int num_stripes, u64 *best_wait, int *best_stripe)
 {
-	u64 best_wait = U64_MAX;
-	int best_stripe = 0;
 	int index;
+	*best_wait = U64_MAX;
+	*best_stripe = 0;
 
-	for (index = first; index < first + num_stripe; index++) {
+	for (index = first; index < first + num_stripes; index++) {
 		u64 read_wait;
 		u64 avg_wait = 0;
 		unsigned long read_ios;
@@ -6027,11 +6038,22 @@ static int btrfs_best_stripe(struct btrfs_fs_info *fs_info,
 		if (read_wait && read_ios && read_wait >= read_ios)
 			avg_wait = div_u64(read_wait, read_ios);
 
-		if (best_wait > avg_wait) {
-			best_wait = avg_wait;
-			best_stripe = index;
+		if (*best_wait > avg_wait) {
+			*best_wait = avg_wait;
+			*best_stripe = index;
 		}
 	}
+}
+
+static int btrfs_read_fastest(struct btrfs_fs_info *fs_info,
+                              struct btrfs_chunk_map *map, int first,
+                              int num_stripes)
+{
+	u64 best_wait;
+	int best_stripe;
+
+	btrfs_best_stripe(fs_info, map, first, num_stripes, &best_wait,
+	                  &best_stripe);
 
 	return best_stripe;
 }
@@ -6131,7 +6153,7 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 		preferred_mirror = btrfs_read_preferred(map, first, num_stripes);
 		break;
 	case BTRFS_READ_POLICY_LATENCY:
-		preferred_mirror = btrfs_best_stripe(fs_info, map, first,
+		preferred_mirror = btrfs_read_fastest(fs_info, map, first,
 								num_stripes);
 		break;
 #endif

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6190,6 +6190,13 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 	else
 		num_stripes = map->num_stripes;
 
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	/* age each possible stripe by 1 IO */
+	for (int i = first; i < first + num_stripes; i++) {
+		atomic64_inc(&map->stripes[i].dev->last_io_age);
+	}
+#endif
+
 	switch (policy) {
 	default:
 		/* Shouldn't happen, just warn and use pid instead of failing */
@@ -6233,13 +6240,21 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 	for (tolerance = 0; tolerance < 2; tolerance++) {
 		if (map->stripes[preferred_mirror].dev->bdev &&
 		    (tolerance || map->stripes[preferred_mirror].dev != srcdev))
-			return preferred_mirror;
+			goto out;
 		for (i = first; i < first + num_stripes; i++) {
 			if (map->stripes[i].dev->bdev &&
-			    (tolerance || map->stripes[i].dev != srcdev))
-				return i;
+			    (tolerance || map->stripes[i].dev != srcdev)) {
+				preferred_mirror = i;
+				goto out;
+			}
 		}
 	}
+
+out:
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	/* reset age of selected stripe */
+	atomic64_set(&map->stripes[preferred_mirror].dev->last_io_age, 0);
+#endif
 
 	/* we couldn't find one that doesn't fail.  Just return something
 	 * and the io error handling code will clean up eventually

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6013,17 +6013,21 @@ static int btrfs_read_preferred(struct btrfs_chunk_map *map, int first,
  * Compute the average latency of the device by dividing total latency by
  * number of IOs.
  */
-#define BTRFS_MAX_AGE_FOR_VALID_LATENCY 1000
+#define BTRFS_MAX_AGE_FOR_VALID_LATENCY 10000
 static u64 btrfs_device_read_latency(struct btrfs_device *device)
 {
 	u64 read_wait = part_stat_read(device->bdev, nsecs[READ]);
+	u64 last_nsecs_read = (u64)atomic64_read(&device->last_nsecs_read);
 	unsigned long read_ios = part_stat_read(device->bdev, ios[READ]);
+	unsigned long last_ios_read = (unsigned long)atomic64_read(&device->last_ios_read);
 	u64 last_io_age = (u64)atomic64_read(&device->last_io_age);
 	u64 avg_wait = 0;
+	s64 delta_read_wait = read_wait - last_nsecs_read;
+	s64 delta_read_ios = read_ios - last_ios_read;
 
 	if (last_io_age >= 0 && last_io_age < BTRFS_MAX_AGE_FOR_VALID_LATENCY
-	    && read_wait && read_ios && read_wait >= read_ios)
-		avg_wait = div_u64(read_wait, read_ios);
+	    && delta_read_wait > 0 && delta_read_ios > 0 && delta_read_wait >= delta_read_ios)
+		avg_wait = div_u64(delta_read_wait, delta_read_ios);
 
 	return avg_wait;
 }
@@ -6174,7 +6178,7 @@ static int btrfs_read_fastest_rr(struct btrfs_fs_info *fs_info,
 }
 #endif
 
-#define BTRFS_OLD_AGE_IO_BURST 20
+#define BTRFS_OLD_AGE_IO_BURST 100
 static int find_live_mirror(struct btrfs_fs_info *fs_info,
 			    struct btrfs_chunk_map *map, int first,
 			    int dev_replace_is_ongoing)
@@ -6256,19 +6260,24 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 
 out:
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
-	/* reset age of selected stripe */
-	s64 current_age, new_age;
 	do {
-		current_age = atomic64_read(&map->stripes[preferred_mirror].dev->last_io_age);
+		/* reset age of selected stripe */
+		s64 current_age;
+		struct btrfs_device *pref_dev = map->stripes[preferred_mirror].dev;
 
+		spin_lock(&pref_dev->latency_lock);
+
+		current_age = atomic64_read(&pref_dev->last_io_age);
 		if (current_age >= BTRFS_MAX_AGE_FOR_VALID_LATENCY) {
-			new_age = -BTRFS_OLD_AGE_IO_BURST;
+			atomic64_set(&pref_dev->last_io_age, -BTRFS_OLD_AGE_IO_BURST);
+			atomic64_set(&pref_dev->last_nsecs_read, part_stat_read(pref_dev->bdev, nsecs[READ]));
+			atomic64_set(&pref_dev->last_ios_read, part_stat_read(pref_dev->bdev, ios[READ]));
 		} else if (current_age >= 0) {
-			new_age = 0;
-		} else {
-			return preferred_mirror;
+			atomic64_set(&pref_dev->last_io_age, 0);
 		}
-	} while (unlikely(atomic64_cmpxchg(&map->stripes[preferred_mirror].dev->last_io_age, current_age, new_age) != current_age));
+
+		spin_unlock(&pref_dev->latency_lock);
+	} while (0);
 #endif
 
 	/* we couldn't find one that doesn't fail.  Just return something

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -1205,6 +1205,7 @@ static int open_fs_devices(struct btrfs_fs_devices *fs_devices,
 	struct btrfs_device *device;
 	struct btrfs_device *latest_dev = NULL;
 	struct btrfs_device *tmp_device;
+	s64 __maybe_unused value = 0;
 	int ret = 0;
 
 	list_for_each_entry_safe(device, tmp_device, &fs_devices->devices,
@@ -1234,10 +1235,21 @@ static int open_fs_devices(struct btrfs_fs_devices *fs_devices,
 	fs_devices->latest_dev = latest_dev;
 	fs_devices->total_rw_bytes = 0;
 	fs_devices->chunk_alloc_policy = BTRFS_CHUNK_ALLOC_REGULAR;
-	fs_devices->read_policy = BTRFS_READ_POLICY_PID;
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	fs_devices->rr_min_contig_read = BTRFS_DEFAULT_RR_MIN_CONTIG_READ;
 	fs_devices->read_devid = latest_dev->devid;
+	fs_devices->read_policy =
+		btrfs_read_policy_to_enum(btrfs_get_mod_read_policy(), &value);
+	if (fs_devices->read_policy == BTRFS_READ_POLICY_RR)
+		fs_devices->fs_stats = true;
+	if (value) {
+		if (fs_devices->read_policy == BTRFS_READ_POLICY_RR)
+			fs_devices->rr_min_contig_read = value;
+		if (fs_devices->read_policy == BTRFS_READ_POLICY_DEVID)
+			fs_devices->read_devid = value;
+	}
+#else
+	fs_devices->read_policy = BTRFS_READ_POLICY_PID;
 #endif
 
 	return 0;

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6013,7 +6013,7 @@ static int btrfs_read_preferred(struct btrfs_chunk_map *map, int first,
  * Compute the average latency of the device by dividing total latency by
  * number of IOs.
  */
-#define BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE 10000
+#define BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE 30000
 static u64 btrfs_device_read_latency(struct btrfs_device *device)
 {
 	u64 read_wait = part_stat_read(device->bdev, nsecs[READ]);
@@ -6178,7 +6178,7 @@ static int btrfs_read_fastest_rr(struct btrfs_fs_info *fs_info,
 }
 #endif
 
-#define BTRFS_DEVICE_LATENCY_CHECKPOINT_BURST_IO 100
+#define BTRFS_DEVICE_LATENCY_CHECKPOINT_BURST_IO 30
 static int find_live_mirror(struct btrfs_fs_info *fs_info,
 			    struct btrfs_chunk_map *map, int first,
 			    int dev_replace_is_ongoing)

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -7577,8 +7577,6 @@ int btrfs_init_devices_late(struct btrfs_fs_info *fs_info)
 	struct btrfs_device *device;
 	int ret = 0;
 
-	fs_devices->fs_info = fs_info;
-
 	mutex_lock(&fs_devices->device_list_mutex);
 	list_for_each_entry(device, &fs_devices->devices, dev_list)
 		device->fs_info = fs_info;

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -1237,6 +1237,7 @@ static int open_fs_devices(struct btrfs_fs_devices *fs_devices,
 	fs_devices->read_policy = BTRFS_READ_POLICY_PID;
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	fs_devices->rr_min_contig_read = BTRFS_DEFAULT_RR_MIN_CONTIG_READ;
+	fs_devices->read_devid = latest_dev->devid;
 #endif
 
 	return 0;
@@ -5974,6 +5975,23 @@ int btrfs_is_parity_mirror(struct btrfs_fs_info *fs_info, u64 logical, u64 len)
 }
 
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
+static int btrfs_read_preferred(struct btrfs_chunk_map *map, int first,
+				int num_stripe)
+{
+	int last = first + num_stripe;
+	int stripe_index;
+
+	for (stripe_index = first; stripe_index < last; stripe_index++) {
+		struct btrfs_device *device = map->stripes[stripe_index].dev;
+
+		if (device->devid == READ_ONCE(device->fs_devices->read_devid))
+			return stripe_index;
+	}
+
+	/* If no read-preferred device, use first stripe */
+	return first;
+}
+
 struct stripe_mirror {
 	u64 devid;
 	int num;
@@ -6064,6 +6082,9 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	case BTRFS_READ_POLICY_RR:
 		preferred_mirror = btrfs_read_rr(map, first, num_stripes);
+		break;
+	case BTRFS_READ_POLICY_DEVID:
+		preferred_mirror = btrfs_read_preferred(map, first, num_stripes);
 		break;
 #endif
 	}

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6269,6 +6269,7 @@ out:
 
 		current_age = atomic64_read(&pref_dev->last_io_age);
 		if (current_age >= BTRFS_MAX_AGE_FOR_VALID_LATENCY) {
+			atomic64_inc(&pref_dev->checkpoints);
 			atomic64_set(&pref_dev->last_io_age, -BTRFS_OLD_AGE_IO_BURST);
 			atomic64_set(&pref_dev->last_nsecs_read, part_stat_read(pref_dev->bdev, nsecs[READ]));
 			atomic64_set(&pref_dev->last_ios_read, part_stat_read(pref_dev->bdev, ios[READ]));

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6013,7 +6013,7 @@ static int btrfs_read_preferred(struct btrfs_chunk_map *map, int first,
  * Compute the average latency of the device by dividing total latency by
  * number of IOs.
  */
-#define BTRFS_MAX_AGE_FOR_VALID_LATENCY 10000
+#define BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE 10000
 static u64 btrfs_device_read_latency(struct btrfs_device *device)
 {
 	u64 read_wait = part_stat_read(device->bdev, nsecs[READ]);
@@ -6025,7 +6025,7 @@ static u64 btrfs_device_read_latency(struct btrfs_device *device)
 	s64 delta_read_wait = read_wait - last_nsecs_read;
 	s64 delta_read_ios = read_ios - last_ios_read;
 
-	if (last_io_age >= 0 && last_io_age < BTRFS_MAX_AGE_FOR_VALID_LATENCY
+	if (last_io_age >= 0 && last_io_age < BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE
 	    && delta_read_wait > 0 && delta_read_ios > 0 && delta_read_wait >= delta_read_ios)
 		avg_wait = div_u64(delta_read_wait, delta_read_ios);
 
@@ -6178,7 +6178,7 @@ static int btrfs_read_fastest_rr(struct btrfs_fs_info *fs_info,
 }
 #endif
 
-#define BTRFS_OLD_AGE_IO_BURST 100
+#define BTRFS_DEVICE_LATENCY_CHECKPOINT_BURST_IO 100
 static int find_live_mirror(struct btrfs_fs_info *fs_info,
 			    struct btrfs_chunk_map *map, int first,
 			    int dev_replace_is_ongoing)
@@ -6268,9 +6268,9 @@ out:
 		spin_lock(&pref_dev->latency_lock);
 
 		current_age = atomic64_read(&pref_dev->last_io_age);
-		if (current_age >= BTRFS_MAX_AGE_FOR_VALID_LATENCY) {
+		if (current_age >= BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE) {
 			atomic64_inc(&pref_dev->checkpoints);
-			atomic64_set(&pref_dev->last_io_age, -BTRFS_OLD_AGE_IO_BURST);
+			atomic64_set(&pref_dev->last_io_age, -BTRFS_DEVICE_LATENCY_CHECKPOINT_BURST_IO);
 			atomic64_set(&pref_dev->last_nsecs_read, part_stat_read(pref_dev->bdev, nsecs[READ]));
 			atomic64_set(&pref_dev->last_ios_read, part_stat_read(pref_dev->bdev, ios[READ]));
 		} else if (current_age >= 0) {

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6094,7 +6094,8 @@ static int btrfs_cmp_devid(const void *a, const void *b)
  * The calculated stripe index is then used to select the corresponding device
  * from the list of devices, which is ordered by devid.
  */
-static int btrfs_read_rr(struct btrfs_chunk_map *map, int first, int num_stripe)
+static int btrfs_read_rr(struct btrfs_chunk_map *map, int first, int num_stripes,
+                         u64 min_latency)
 {
 	struct stripe_mirror stripes[BTRFS_RAID1_MAX_MIRRORS] = { 0 };
 	struct btrfs_device *device  = map->stripes[first].dev;
@@ -6108,11 +6109,24 @@ static int btrfs_read_rr(struct btrfs_chunk_map *map, int first, int num_stripe)
 	min_reads_per_dev = READ_ONCE(fs_info->fs_devices->rr_min_contig_read) >>
 						       fs_info->sectorsize_bits;
 
-	for (int i = first; i < first + num_stripe; i++) {
+	for (int i = first; i < first + num_stripes; i++) {
+		if (min_latency > 0) {
+			u64 avg_wait = btrfs_device_read_latency(map->stripes[i].dev);
+			if (min_latency < avg_wait)
+				continue;
+		}
+
 		stripes[count_stripes].devid = map->stripes[i].dev->devid;
 		stripes[count_stripes].num = i;
 		count_stripes++;
 	}
+
+	/* if the caller passed a minimum latency and we filtered for no
+	 * stripes, return -1 to indicate that no stripe qualified.
+	 */
+	if (unlikely(min_latency && !count_stripes))
+		return -1;
+
 	sort(stripes, count_stripes, sizeof(struct stripe_mirror),
 	     btrfs_cmp_devid, NULL);
 
@@ -6152,7 +6166,7 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 		break;
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	case BTRFS_READ_POLICY_RR:
-		preferred_mirror = btrfs_read_rr(map, first, num_stripes);
+		preferred_mirror = btrfs_read_rr(map, first, num_stripes, 0);
 		break;
 	case BTRFS_READ_POLICY_DEVID:
 		preferred_mirror = btrfs_read_preferred(map, first, num_stripes);

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6019,18 +6019,20 @@ static u64 btrfs_device_read_latency(struct btrfs_device *device)
 	u64 avg_wait = 0;
 
 	if (likely(device->bdev)) {
-		u64 read_wait = part_stat_read(device->bdev, nsecs[READ]);
-		u64 last_nsecs_read = (u64)atomic64_read(&device->last_nsecs_read);
-		unsigned long read_ios = part_stat_read(device->bdev, ios[READ]);
-		unsigned long last_ios_read = (unsigned long)atomic64_read(&device->last_ios_read);
 		u64 last_io_age = (u64)atomic64_read(&device->last_io_age);
 
-		s64 delta_read_wait = read_wait - last_nsecs_read;
-		s64 delta_read_ios = read_ios - last_ios_read;
+		if (likely(last_io_age >= 0 && last_io_age < BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE)) {
+			u64 read_wait = part_stat_read(device->bdev, nsecs[READ]);
+			u64 last_nsecs_read = (u64)atomic64_read(&device->last_nsecs_read);
+			unsigned long read_ios = part_stat_read(device->bdev, ios[READ]);
+			unsigned long last_ios_read = (unsigned long)atomic64_read(&device->last_ios_read);
 
-		if (last_io_age >= 0 && last_io_age < BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE
-		    && delta_read_wait > 0 && delta_read_ios > 0 && delta_read_wait >= delta_read_ios)
-			avg_wait = div_u64(delta_read_wait, delta_read_ios);
+			s64 delta_read_wait = read_wait - last_nsecs_read;
+			s64 delta_read_ios = read_ios - last_ios_read;
+
+			if (delta_read_wait > 0 && delta_read_ios > 0 && delta_read_wait >= delta_read_ios)
+				avg_wait = div_u64(delta_read_wait, delta_read_ios);
+		}
 	}
 
 	return avg_wait;

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6133,6 +6133,42 @@ static int btrfs_read_rr(struct btrfs_chunk_map *map, int first, int num_stripes
 	read_cycle = total_reads / min_reads_per_dev;
 	return stripes[read_cycle % count_stripes].num;
 }
+
+/*
+ * btrfs_read_fastest_rr.
+ *
+ * Select a stripe for reading using a hybrid algorithm:
+ *
+ *  1. Determine the fastest stripe using btrfs_best_stripe.
+ *  2. Add 20% headroom to the selected latency.
+ *  3. Select a stripe using btrfs_read_rr filtered by latency.
+ */
+static int btrfs_read_fastest_rr(struct btrfs_fs_info *fs_info,
+                                 struct btrfs_chunk_map *map, int first,
+                                 int num_stripes)
+{
+	u64 min_latency;
+	int ret_stripe = -1;
+
+	/* find the lowest latency of all stripes first */
+	btrfs_best_stripe(fs_info, map, first, num_stripes, &min_latency,
+	                     &ret_stripe);
+
+	/* min_latency will be 0 if no latency has been recorded yet,
+	 * add 25% headroom otherwise, and round-robin among the fast
+	 * stripes only.
+	 */
+	if (likely(min_latency)) {
+		min_latency += (min_latency >> 2);
+		ret_stripe = btrfs_read_rr(map, first, num_stripes, min_latency);
+	}
+
+	/* retry with default round-robin if no stripe has been found */
+	if (unlikely(ret_stripe < 0))
+		ret_stripe = btrfs_read_rr(map, first, num_stripes, 0);
+
+	return ret_stripe;
+}
 #endif
 
 static int find_live_mirror(struct btrfs_fs_info *fs_info,
@@ -6174,6 +6210,10 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 	case BTRFS_READ_POLICY_LATENCY:
 		preferred_mirror = btrfs_read_fastest(fs_info, map, first,
 								num_stripes);
+		break;
+	case BTRFS_READ_POLICY_LATENCY_RR:
+		preferred_mirror = btrfs_read_fastest_rr(fs_info, map, first,
+		                                         num_stripes);
 		break;
 #endif
 	}

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -12,6 +12,9 @@
 #include <linux/uuid.h>
 #include <linux/list_sort.h>
 #include <linux/namei.h>
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+#include <linux/part_stat.h>
+#endif
 #include "misc.h"
 #include "ctree.h"
 #include "disk-io.h"
@@ -6004,6 +6007,35 @@ static int btrfs_read_preferred(struct btrfs_chunk_map *map, int first,
 	return first;
 }
 
+static int btrfs_best_stripe(struct btrfs_fs_info *fs_info,
+			     struct btrfs_chunk_map *map, int first,
+			     int num_stripe)
+{
+	u64 best_wait = U64_MAX;
+	int best_stripe = 0;
+	int index;
+
+	for (index = first; index < first + num_stripe; index++) {
+		u64 read_wait;
+		u64 avg_wait = 0;
+		unsigned long read_ios;
+		struct btrfs_device *device = map->stripes[index].dev;
+
+		read_wait = part_stat_read(device->bdev, nsecs[READ]);
+		read_ios = part_stat_read(device->bdev, ios[READ]);
+
+		if (read_wait && read_ios && read_wait >= read_ios)
+			avg_wait = div_u64(read_wait, read_ios);
+
+		if (best_wait > avg_wait) {
+			best_wait = avg_wait;
+			best_stripe = index;
+		}
+	}
+
+	return best_stripe;
+}
+
 struct stripe_mirror {
 	u64 devid;
 	int num;
@@ -6097,6 +6129,10 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 		break;
 	case BTRFS_READ_POLICY_DEVID:
 		preferred_mirror = btrfs_read_preferred(map, first, num_stripes);
+		break;
+	case BTRFS_READ_POLICY_LATENCY:
+		preferred_mirror = btrfs_best_stripe(fs_info, map, first,
+								num_stripes);
 		break;
 #endif
 	}

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6013,13 +6013,16 @@ static int btrfs_read_preferred(struct btrfs_chunk_map *map, int first,
  * Compute the average latency of the device by dividing total latency by
  * number of IOs.
  */
+#define BTRFS_MAX_AGE_FOR_VALID_LATENCY 1000
 static u64 btrfs_device_read_latency(struct btrfs_device *device)
 {
 	u64 read_wait = part_stat_read(device->bdev, nsecs[READ]);
 	unsigned long read_ios = part_stat_read(device->bdev, ios[READ]);
+	u64 last_io_age = (u64)atomic64_read(&device->last_io_age);
 	u64 avg_wait = 0;
 
-	if (read_wait && read_ios && read_wait >= read_ios)
+	if (last_io_age < BTRFS_MAX_AGE_FOR_VALID_LATENCY
+	    && read_wait && read_ios && read_wait >= read_ios)
 		avg_wait = div_u64(read_wait, read_ios);
 
 	return avg_wait;

--- a/fs/btrfs/volumes.c
+++ b/fs/btrfs/volumes.c
@@ -6056,6 +6056,44 @@ static void btrfs_best_stripe(struct btrfs_fs_info *fs_info,
 	}
 }
 
+static unsigned int part_in_flight(struct block_device *part)
+{
+	unsigned int inflight = 0;
+	int cpu;
+
+	for_each_possible_cpu(cpu) {
+		inflight += part_stat_local_read_cpu(part, in_flight[0], cpu) +
+			    part_stat_local_read_cpu(part, in_flight[1], cpu);
+	}
+	if ((int)inflight < 0)
+		inflight = 0;
+
+	return inflight;
+}
+
+/*
+ * btrfs_earliest_stripe
+ *
+ * Select a stripe from the device with shortest in-flight requests.
+ */
+static int btrfs_read_earliest(struct btrfs_fs_info *fs_info,
+                               struct btrfs_chunk_map *map, int first,
+                               int num_stripes)
+{
+	u64 best_in_flight = U64_MAX;
+	int best_stripe = 0;
+
+	for (int index = first; index < first + num_stripes; index++) {
+		u64 in_flight = part_in_flight(map->stripes[index].dev->bdev);
+		if (best_in_flight > in_flight) {
+			best_in_flight = in_flight;
+			best_stripe = index;
+		}
+	}
+
+	return best_stripe;
+}
+
 static int btrfs_read_fastest(struct btrfs_fs_info *fs_info,
                               struct btrfs_chunk_map *map, int first,
                               int num_stripes)
@@ -6230,6 +6268,10 @@ static int find_live_mirror(struct btrfs_fs_info *fs_info,
 	case BTRFS_READ_POLICY_LATENCY_RR:
 		preferred_mirror = btrfs_read_fastest_rr(fs_info, map, first,
 		                                         num_stripes);
+		break;
+	case BTRFS_READ_POLICY_QUEUE:
+		preferred_mirror = btrfs_read_earliest(fs_info, map, first,
+		                                       num_stripes);
 		break;
 #endif
 	}

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -565,6 +565,7 @@ struct btrfs_device_info {
 	u64 dev_offset;
 	u64 max_avail;
 	u64 total_avail;
+	int alloc_hint;
 };
 
 struct btrfs_raid_attr {

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -836,6 +836,8 @@ int btrfs_bg_type_to_factor(u64 flags);
 const char *btrfs_bg_type_to_raid_name(u64 flags);
 int btrfs_verify_dev_extents(struct btrfs_fs_info *fs_info);
 bool btrfs_repair_one_zone(struct btrfs_fs_info *fs_info, u64 logical);
+int btrfs_update_device(struct btrfs_trans_handle *trans,
+                                       struct btrfs_device *device);
 
 bool btrfs_pinned_by_swapfile(struct btrfs_fs_info *fs_info, void *ptr);
 const u8 *btrfs_sb_fsid_ptr(const struct btrfs_super_block *sb);

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -310,6 +310,8 @@ enum btrfs_read_policy {
 	BTRFS_READ_POLICY_RR,
 	/* Use the lowest-latency device dynamically */
 	BTRFS_READ_POLICY_LATENCY,
+	/* Use hybrid approach of lowest-latency and round-robin */
+	BTRFS_READ_POLICY_LATENCY_RR,
 	/* Read from the specific device */
 	BTRFS_READ_POLICY_DEVID,
 #endif

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -201,6 +201,7 @@ struct btrfs_device {
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	/* store an age of last read access */
 	atomic64_t last_io_age;
+	atomic64_t checkpoints;
 
 	/* lock while updating values */
 	spinlock_t latency_lock;

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -326,6 +326,8 @@ enum btrfs_read_policy {
 	BTRFS_READ_POLICY_LATENCY,
 	/* Use hybrid approach of lowest-latency and round-robin */
 	BTRFS_READ_POLICY_LATENCY_RR,
+	/* Read from the device with least in-flight requests */
+	BTRFS_READ_POLICY_QUEUE,
 	/* Read from the specific device */
 	BTRFS_READ_POLICY_DEVID,
 #endif

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -308,6 +308,8 @@ enum btrfs_read_policy {
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	/* Balancing raid1 reads across all striped devices (round-robin) */
 	BTRFS_READ_POLICY_RR,
+	/* Read from the specific device */
+	BTRFS_READ_POLICY_DEVID,
 #endif
 	BTRFS_NR_READ_POLICY,
 };
@@ -441,6 +443,9 @@ struct btrfs_fs_devices {
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	/* Min contiguous reads before switching to next device. */
 	int rr_min_contig_read;
+
+	/* Device to be used for reading in case of RAID1. */
+	u64 read_devid;
 #endif
 
 #ifdef CONFIG_BTRFS_DEBUG

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -296,6 +296,8 @@ enum btrfs_chunk_allocation_policy {
 	BTRFS_CHUNK_ALLOC_ZONED,
 };
 
+#define BTRFS_DEFAULT_RR_MIN_CONTIG_READ	(SZ_256K)
+#define BTRFS_RAID1_MAX_MIRRORS			(4)
 /*
  * Read policies for mirrored block group profiles, read picks the stripe based
  * on these policies.
@@ -303,6 +305,10 @@ enum btrfs_chunk_allocation_policy {
 enum btrfs_read_policy {
 	/* Use process PID to choose the stripe */
 	BTRFS_READ_POLICY_PID,
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	/* Balancing raid1 reads across all striped devices (round-robin) */
+	BTRFS_READ_POLICY_RR,
+#endif
 	BTRFS_NR_READ_POLICY,
 };
 
@@ -431,6 +437,11 @@ struct btrfs_fs_devices {
 
 	/* Policy used to read the mirrored stripes. */
 	enum btrfs_read_policy read_policy;
+
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	/* Min contiguous reads before switching to next device. */
+	int rr_min_contig_read;
+#endif
 
 #ifdef CONFIG_BTRFS_DEBUG
 	/* Checksum mode - offload it or do it synchronously. */

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -202,6 +202,7 @@ struct btrfs_device {
 	/* store an age of last read access */
 	atomic64_t last_io_age;
 	atomic64_t checkpoints;
+	atomic64_t stripe_ignored;
 
 	/* lock while updating values */
 	spinlock_t latency_lock;

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -201,6 +201,13 @@ struct btrfs_device {
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	/* store an age of last read access */
 	atomic64_t last_io_age;
+
+	/* lock while updating values */
+	spinlock_t latency_lock;
+
+	/* last latency values for short term latency calculation */
+	atomic64_t last_nsecs_read;
+	atomic64_t last_ios_read;
 #endif
 };
 

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -185,7 +185,7 @@ struct btrfs_device {
 	 * enum btrfs_dev_stat_values in ioctl.h */
 	int dev_stats_valid;
 
-	/* Counter to record the change of device stats */
+	/* Counter to record of the change of device stats */
 	atomic_t dev_stats_ccnt;
 	atomic_t dev_stat_values[BTRFS_DEV_STAT_VALUES_MAX];
 
@@ -417,6 +417,8 @@ struct btrfs_fs_devices {
 	bool seeding;
 	/* The mount needs to use a randomly generated fsid. */
 	bool temp_fsid;
+	/* Enable/disable the filesystem stats tracking */
+	bool fs_stats;
 
 	struct btrfs_fs_info *fs_info;
 	/* sysfs kobjects */

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -197,6 +197,11 @@ struct btrfs_device {
 
 	/* Bandwidth limit for scrub, in bytes */
 	u64 scrub_speed_max;
+
+#ifdef CONFIG_BTRFS_EXPERIMENTAL
+	/* store an age of last read access */
+	atomic64_t last_io_age;
+#endif
 };
 
 /*

--- a/fs/btrfs/volumes.h
+++ b/fs/btrfs/volumes.h
@@ -308,6 +308,8 @@ enum btrfs_read_policy {
 #ifdef CONFIG_BTRFS_EXPERIMENTAL
 	/* Balancing raid1 reads across all striped devices (round-robin) */
 	BTRFS_READ_POLICY_RR,
+	/* Use the lowest-latency device dynamically */
+	BTRFS_READ_POLICY_LATENCY,
 	/* Read from the specific device */
 	BTRFS_READ_POLICY_DEVID,
 #endif

--- a/include/uapi/linux/btrfs_tree.h
+++ b/include/uapi/linux/btrfs_tree.h
@@ -578,6 +578,20 @@ struct btrfs_node {
 	struct btrfs_key_ptr ptrs[];
 } __attribute__ ((__packed__));
 
+/* dev_item.type */
+
+/* btrfs chunk allocation hints */
+#define BTRFS_DEV_ALLOCATION_MASK_BIT_COUNT	3
+/* preferred data chunk, but metadata chunk allowed */
+#define BTRFS_DEV_ALLOCATION_PREFERRED_DATA	(0ULL)
+/* preferred metadata chunk, but data chunk allowed */
+#define BTRFS_DEV_ALLOCATION_PREFERRED_METADATA	(1ULL)
+/* only metadata chunk are allowed */
+#define BTRFS_DEV_ALLOCATION_METADATA_ONLY	(2ULL)
+/* only data chunk allowed */
+#define BTRFS_DEV_ALLOCATION_DATA_ONLY		(3ULL)
+/* 5..7 are unused values */
+
 struct btrfs_dev_item {
 	/* the internal btrfs device id */
 	__le64 devid;

--- a/include/uapi/linux/btrfs_tree.h
+++ b/include/uapi/linux/btrfs_tree.h
@@ -590,6 +590,8 @@ struct btrfs_node {
 #define BTRFS_DEV_ALLOCATION_METADATA_ONLY	(2ULL)
 /* only data chunk allowed */
 #define BTRFS_DEV_ALLOCATION_DATA_ONLY		(3ULL)
+/* preferred no chunk, but chunks allowed */
+#define BTRFS_DEV_ALLOCATION_PREFERRED_NONE	(4ULL)
 /* 5..7 are unused values */
 
 struct btrfs_dev_item {

--- a/include/uapi/linux/btrfs_tree.h
+++ b/include/uapi/linux/btrfs_tree.h
@@ -592,7 +592,9 @@ struct btrfs_node {
 #define BTRFS_DEV_ALLOCATION_DATA_ONLY		(3ULL)
 /* preferred no chunk, but chunks allowed */
 #define BTRFS_DEV_ALLOCATION_PREFERRED_NONE	(4ULL)
-/* 5..7 are unused values */
+/* no chunks allowed */
+#define BTRFS_DEV_ALLOCATION_NONE_ONLY	        (5ULL)
+/* 6..7 are unused values */
 
 struct btrfs_dev_item {
 	/* the internal btrfs device id */


### PR DESCRIPTION
Export patch series: https://github.com/kakra/linux/pull/36.patch

*Here's a good guide by @Forza-tng: https://wiki.tnonline.net/w/Btrfs/Allocator_Hints. Please leave them a nice comment. Thanks.* :-)

- **Allocator hint patches:** Allows to prefer SSDs for meta-data allocations while excluding HDDs from meta-data allocation, greatly improves btrfs responsiveness, file system remains compatible with non-patched systems but won't honor allocation preferences then (re-balance needed to fix that after going back to a patched kernel)
- **RAID1 read balance patches:** Allows to round-robin RAID1 read requests across multiple disks, or prefer the device with the lowest latency. In some non-scientific tests, this can easily cut loading times in some games in half. 

### Allocator hints

To make use of the allocator hints, add these to your kernel. Then run `btrfs device usage /path/to/btrfs` and take note of which device IDs are SSDs and which are HDDs.

Go to `/sys/fs/btrfs/BTRFS-UUID/devinfo` and run:
- `echo 0 | sudo tee HDD-ID/type` to prefer writing data to this device (btrfs will then prefer allocating data chunks from this device before considering other devices) - recommended for HDDs, set by default
- `echo 1 | sudo tee SSD-ID/type` to prefer writing meta-data to this device (btrfs will then prefer allocating meta-data chunks from this device before considering other devices) - recommended for SSDs
- There's also type 2 and 3 which write meta-data only (2) or data only (3) to the specified device - not recommended, can result in early no-space situations
- **Added 2024-06-27:** Type 4 can be used to *avoid* allocating new chunks from a device, useful if you plan on removing the device from the pool in the future: `echo 4 | sudo tee LEGACY-ID/type`
- **Added 2024-12-06:** Type 5 can be used to *prevent* allocating any chunks from a device, useful if you plan on removing multiple devices from the pool in parallel: `echo 5 | sudo tee LEGACY-ID/type`
- **NEVER EVER** use type 2 or 3 if you only have one type of device unless you know what you do and why you are doing this
- The default "preferred" heuristics (0 and 1) are good enough because btrfs will always allocate from devices with most space first (respecting the "preferred" type with this patch)
- After changing the values, a one-time meta-data and/or data balance (optionally filtered to the affected device IDs) is needed

**Important note:** This recommends to use at least two independent SSDs so btrfs meta-data raid1 requirement is still satisfied. You can, however, create two partitions on the same SSD but then it's no longer protected against hardware faults, it's essentially dup-quality meta-data then, not raid1. Before sizing the partitions, look at `btrfs device usage` to find the amount of meta-data, at least double that size to size your meta-data partitions.

This can be combined with bcache by directly using meta-data partitions as a native SSD partition for btrfs, and only using data partitions routed through bcache. This also takes a lot of meta-data pressure from bcache, making it more efficient and less write-wearing as a result.

**Real-world example**

In this example, `sde` is a 1 TB SSD having two meta-data partitions (2x 128 GB) with the remaining space dedicated to a single bcache partition attached to my btrfs pool devices:
```
# btrfs device usage /
/dev/bcache2, ID: 1
   Device size:             3.63TiB
   Device slack:            3.50KiB
   Data,single:             1.66TiB
   Unallocated:             1.97TiB

/dev/bcache0, ID: 2
   Device size:             3.63TiB
   Device slack:            3.50KiB
   Data,single:             1.66TiB
   Unallocated:             1.97TiB

/dev/bcache1, ID: 3
   Device size:             2.70TiB
   Device slack:            3.50KiB
   Data,single:           752.00GiB
   Unallocated:             1.96TiB

/dev/sde4, ID: 4
   Device size:           128.00GiB
   Device slack:              0.00B
   Metadata,RAID1:         27.00GiB
   System,RAID1:           32.00MiB
   Unallocated:           100.97GiB

/dev/sde5, ID: 5
   Device size:           128.01GiB
   Device slack:              0.00B
   Metadata,RAID1:         27.00GiB
   System,RAID1:           32.00MiB
   Unallocated:           100.98GiB

# bcache show
Name            Type            State                   Bname           AttachToDev
/dev/sdd2       1 (data)        dirty(running)          bcache1         /dev/sde2
/dev/sdb2       1 (data)        dirty(running)          bcache2         /dev/sde2
/dev/sde2       3 (cache)       active                  N/A             N/A
/dev/sdc2       1 (data)        clean(running)          bcache3         /dev/sde2
/dev/sda2       1 (data)        dirty(running)          bcache0         /dev/sde2
```

A curious reader may find that `sde1` and `sde3` are missing, which is my EFI boot partition (sde1) and swap space (sde3).

### Read Policies aka "RAID1 read balancer"

To use the balancer, `CONFIG_BTRFS_EXPERIMENTAL=y` is needed while building the kernel. The balancer offers six modes:

- **pid** provides the old PID-based balancer and is the default.
- **round-robin** provides the best performance if all member disks are of the same type. Performance may be unstable with bcache. Preferred for parallel workloads like servers.
- **latency** provides best performance if using asymmetric RAID configurations with mixed device types (e.g. SSD paired with HDD). Performance may be unstable with bcache but may increase bcache hit rates over time. Preferred for latency-sensitive workloads like desktop.
- **latency-rr** tries to combine round-robin and latency into one hybrid approach by using round-robin across a set of stripes within a 125% margin of the best latency. I am currently testing this and have not yet discovered the benefits or downsides but in theory it should prefer the fastest stripes for small requests while it switches over to using all stripes for large continuous requests. Technically, this works either as latency or round-robin with just two mirrors, should work better with more mirrors.
- **queue** diverts each request to a stripe with the shortest IO queue (in-flight requests) and works exceptionally (and unexpected) well with all workloads I tested: It massively outperforms all other policies in each benchmark scenario and in virtualization workloads.
- **devid** prefers reading from a specified device ID. Similar to **latency**, it provides best performance if you know one drive is faster than another. This could stabilize performance with bcache as it will prefer caching data only of specified the disk. Defaults to the latest disk added to the pool.

Combined with bcache, performance is unstable with both `round-robin` and `latency` because latency and throughput depend on whether data is cached or not - but still it is overall better than the old PID balancer.

Unexpectedly, `queue` performs exceptionally well on my mixed device setup. YMMV with identical member devices. It outperforms all other policies in each discipline and benchmark.

To use the balancer, use `btrfs.read_policy=<pid,round-robin,latency,latency-rr,queue,devid:#>` on the kernel cmdline. There's also a sysfs interface at `/sys/fs/btrfs/<UUID>/read_policy` to switch balancers on demand (e.g., for benchmarks). See `modinfo btrfs` for more information.

**Benchmark results:** https://gist.github.com/kakra/ce99896e5915f9b26d13c5637f56ff37

**Note 1:** The latency calculation currently uses an average of the full history of requests only - which is bad because it will cancel out changing variations over time. A better approach would be to use an EMA (exponential moving average) with an alpha of 1/8 or 1/16. This requires to sample individual bio latency and thus requires to change structs and code in other parts of btrfs. I'm not very familiar with all the internal structures yet, and the feature is still guarded by `CONFIG_BTRFS_EXPERIMENTAL`, making that approach more complex. OTOH, having a permanent EMA right in the bio structures of btrfs could prove useful in other areas of btrfs.

**Note 2:** In theory, both latency modes should automatically prefer faster zones of HDDs and properly switch stripes automatically. In practice, this is probably overruled by **note 1** except most of your data is in specific zones by coincidence, in which case the average would properly hold some sort of "zone performance".

**Note 3:** With high CPU core counts, `queue` might have a measurable CPU overhead due to queue length calculation (per-core counters have to be summed per each request).

**Real-world example**

Some simple tests have shown that both the round-robin and latency balancers can increase throughput while loading games from 200-300 MB/s to 500-700 MB/s when combined with bcache.

**Important note:** This will be officially available with kernel 6.15 or later, excluding the latency balancer. I've included it because I think it can provide better performance in edge cases, e.g. asymmetric RAID or bcache. It may also provide better performance on the desktop because on the desktop, latency is more important than throughput. The latency balancer is thus an experiment and may go away. But I will keep it until at least the next LTS kernel.

---

### Description / instructions for balancing
*(AI generated after training with some stats, observations and incremental development steps)*

**Interpreting the Btrfs `read_stats` Sysfs Output**

The `/sys/fs/btrfs/<UUID>/devinfo/<DEVID>/read_stats` file, enhanced by these patches, offers valuable insights into the dynamic read balancing behavior and performance of individual devices within a Btrfs RAID1/10/1C3/4 setup. Here's a breakdown of the fields:
```
cumulative ios %lu wait %llu avg %llu checkpoint ios %ld wait %lld avg %llu age %lld count %llu ignored %lld
```

- **`cumulative ios %lu`**: The total count of read I/O operations completed on this specific device since the filesystem was mounted.
- **`cumulative wait %llu`**: The total time (in nanoseconds) accumulated waiting for all cumulative read IOs on this device.
- **`cumulative avg %llu`**: The long-term average read latency (`cumulative wait / cumulative ios`) in nanoseconds. This represents the device's average performance over its entire operational history within the current mount. It changes very slowly and can be heavily influenced by caching layers (like bcache or the page cache) if present.

- **`checkpoint ios %ld`**: The number of read IOs completed *since the last checkpoint*. A checkpoint is established when a device undergoes "rehabilitation" – meaning its `age` counter reached the `BTRFS_DEVICE_LATENCY_CHECKPOINT_AGE` threshold, triggering a read probe and a reset of these checkpoint statistics. For devices that have never been rehabilitated, this value will equal `cumulative ios`.
- **`checkpoint wait %lld`**: The total time (in nanoseconds) accumulated waiting for reads *since the last checkpoint*.
- **`checkpoint avg %llu`**: The average read latency (`checkpoint wait / checkpoint ios`) calculated *only* using the IOs since the last checkpoint. This is a **key metric reflecting recent performance**. It's much more responsive to current conditions than the cumulative average, especially after a period of being ignored.

- **`age %lld`**: This counter tracks how "stale" the device is in terms of read selection. It increments each time a read balancing decision is made for a stripe group containing this device, but *another* device from that group is chosen.
    - `0`: The device was selected for a read very recently (in the last relevant balancing decision).
    - `> 0`: The device has been ignored for this many consecutive selection events where it was a candidate. A high value indicates it's consistently considered slower or less preferred than its peers.
    - `< 0`: The device has just been rehabilitated (hit the `age` threshold). It is now in a "burst IO" probation period (e.g., starting at -100 and incrementing towards 0). During this negative age phase, its reported latency is forced to 0 to guarantee it receives reads.
- **`count %llu`**: The number of times this device has triggered the rehabilitation mechanism by reaching the `age` threshold. A high count suggests the device is frequently deemed too slow by the latency policy or is subject to other selection biases (like non-balancing metadata reads).
- **`ignored %lld`**: A counter incremented every time this device was a *candidate* for a read, but the balancing policy ultimately selected a *different* device from the same stripe group. This provides insight into how often the policy actively chooses a peer over this device, indicating relative preference or "fairness" of the algorithm.

**How to Use These Stats:**

- **Identify Slow Devices:** Devices consistently showing a high `checkpoint avg` (compared to peers) and a high, frequently reset `age` are likely performance bottlenecks under the current load.
- **Assess Policy Effectiveness:** Compare `cumulative avg` and `checkpoint avg`. A large difference after rehabilitation (`count > 0`) shows the policy is adapting to performance changes more quickly than the cumulative average would suggest.
- **Detect Selection Bias:** A device with a good `checkpoint avg` but a persistently high `age` and `ignored` count (like NVMe metadata mirrors sometimes exhibit) points towards a selection bias not based purely on latency.
- **Tune Rehabilitation:** The `age` and `count` values help evaluate the `AGE_THRESHOLD` and `IO_BURST` parameters. If `age` hits the threshold very frequently, it might be too low. If `checkpoint ios` barely increases after a reset, the `IO_BURST` might be too short (or the device becomes slow again immediately).

These enhanced statistics provide a powerful diagnostic tool for understanding and fine-tuning Btrfs's read balancing behavior in complex, real-world storage environments.